### PR TITLE
Made Premake target latest windows system-version.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -29,6 +29,7 @@ local function configure_project_base()
   -- Windows
   filter "system:windows"
     defines { "NOMINMAX", "WIN32_LEAN_AND_MEAN" }
+    systemversion "latest"
 
   -- Reset filter
   filter{}


### PR DESCRIPTION
By default, Premake targeted the Windows 8.1 SDK. Changed to latest.