### PR TITLE
Created GameState system and a GameplayState class.

### DIFF
--- a/include/Application.h
+++ b/include/Application.h
@@ -34,10 +34,9 @@ namespace ccm
 		}
 
 		template<typename T, typename... Args>
-		void pushState(Args... args)
+		void pushState(Args&&... args)
 		{
-			std::unique_ptr<GameState> nextState = std::make_unique<T>(args...);
-			m_gameStates.push_back(std::move(nextState));
+			m_gameStates.push_back(std::make_unique<T>(std::forward<Args>(args)...));
 		}
 
 		void popState();

--- a/include/Application.h
+++ b/include/Application.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <memory>
+#include <vector>
 #include <SDL.h>
 #include <SDL_main.h>
 #include <SDL_video.h>
+
+#include "BaseGameState.h"
 
 namespace ccm
 {
@@ -21,8 +25,26 @@ namespace ccm
 
 		bool m_quit{ false };
 
+		template<typename T, typename... Args>
+		void replaceTopState(Args... args)
+		{
+			std::unique_ptr<GameState> nextState = std::make_unique<T>(args...);
+			popState()
+			m_gameStates.push_back(std::move(nextState));
+		}
+
+		template<typename T, typename... Args>
+		void pushState(Args... args)
+		{
+			std::unique_ptr<GameState> nextState = std::make_unique<T>(args...);
+			m_gameStates.push_back(std::move(nextState));
+		}
+
+		void popState();
+
 	private:
 		SDL_Window* m_window{ nullptr };
 		SDL_Renderer* m_renderer{ nullptr };
+		std::vector<std::unique_ptr<GameState>> m_gameStates;
 	};
 }

--- a/include/BaseGameState.h
+++ b/include/BaseGameState.h
@@ -5,8 +5,8 @@
 class GameState
 {
 public:
-	GameState() {}
-	virtual ~GameState() {}
+	GameState() = default;
+	virtual ~GameState() = default;
 	
 	virtual void handleEvent(SDL_Event& event) {}
 	// TODO: Have update take in a deltatime

--- a/include/BaseGameState.h
+++ b/include/BaseGameState.h
@@ -8,7 +8,7 @@ public:
 	GameState() = default;
 	virtual ~GameState() = default;
 	
-	virtual void handleEvent(SDL_Event& event) {}
+	virtual void handleEvent(const SDL_Event& event) {}
 	// TODO: Have update take in a deltatime
 	virtual void update() {}
 };

--- a/include/BaseGameState.h
+++ b/include/BaseGameState.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <SDL.h>
+
+class GameState
+{
+public:
+	GameState() {}
+	virtual ~GameState() {}
+	
+	virtual void handleEvent(SDL_Event& event) {}
+	// TODO: Have update take in a deltatime
+	virtual void update() {}
+};

--- a/include/GameplayState.h
+++ b/include/GameplayState.h
@@ -11,6 +11,6 @@ public:
 	// Make un-default when actually needed
 	GameplayState() = default;
 
-	void handleEvent(SDL_Event& event) override;
+	void handleEvent(const SDL_Event& event) override;
 	void update() override;
 };

--- a/include/GameplayState.h
+++ b/include/GameplayState.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "BaseGameState.h"
+
+// This is where the main gameplay will occur
+class GameplayState : public GameState
+{
+public:
+	// Could pass in state such as settings that were
+	// toggled on the start screen or stuff like that
+	// Make un-default when actually needed
+	GameplayState() = default;
+
+	void handleEvent(SDL_Event& event) override;
+	void update() override;
+};

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -62,7 +62,7 @@ namespace ccm
 					break;
 
 				default:
-					if (m_gameStates.size() > 0)
+					if (!m_gameStates.empty())
 					{
 						m_gameStates.back()->handleEvent(event);
 					}
@@ -76,7 +76,7 @@ namespace ccm
 
 	void Application::popState()
 	{
-		if (m_gameStates.size() > 0)
+		if (!m_gameStates.empty())
 		{
 			m_gameStates.pop_back();
 		}

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,4 +1,5 @@
 #include "Application.h"
+#include "GameplayState.h"
 
 #include <iostream>
 
@@ -30,6 +31,10 @@ namespace ccm
 			std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError() << std::endl;
 			m_quit = true;
 		}
+
+		/* Pushes the first state onto the stack. */
+		// TODO: Change this to the start screen state or whatever later
+		pushState<GameplayState>();
 	}
 
 	Application::~Application()
@@ -55,7 +60,29 @@ namespace ccm
 				case SDL_QUIT:
 					m_quit = true;
 					break;
+
+				default:
+					if (m_gameStates.size() > 0)
+					{
+						m_gameStates.back()->handleEvent(event);
+					}
+					else
+					{
+						std::cerr << "No game states in vector." << std::endl;
+					}
 			}
+		}
+	}
+
+	void Application::popState()
+	{
+		if (m_gameStates.size() > 0)
+		{
+			m_gameStates.pop_back();
+		}
+		else
+		{
+			std::cerr << "Attempted to pop state off empty vector." << std::endl;
 		}
 	}
 }

--- a/src/GameplayState.cpp
+++ b/src/GameplayState.cpp
@@ -1,6 +1,6 @@
 #include "GameplayState.h"
 
-void GameplayState::handleEvent(SDL_Event& event)
+void GameplayState::handleEvent(const SDL_Event& event)
 {
 	switch (event.type)
 	{

--- a/src/GameplayState.cpp
+++ b/src/GameplayState.cpp
@@ -1,0 +1,19 @@
+#include "GameplayState.h"
+
+void GameplayState::handleEvent(SDL_Event& event)
+{
+	switch (event.type)
+	{
+		// TODO: Handle necessary events (not SDL_QUIT, that is
+		// already handled) here
+
+	default:
+		break;
+	}
+}
+
+void GameplayState::update()
+{
+	// Update tetris cell pieces, etc
+	// Should also take in a deltatime in the future
+}


### PR DESCRIPTION
The GameState class is in BaseGameState.h and will be the base class for all game states (GameplayState, StartScreenState, GameOverState, etc). Use `Application::pushState()` to put another state on the stack without destroying your original one. This is useful if you want to resume the previous one later (like from LevelPassedState backed to the same GameplayState). 
Use `Application::replaceState()` when you want to get rid of your current state (e.g. moving from StartScreenState to GameplayState.