### PR TITLE
Rect

### DIFF
--- a/include/Rect.h
+++ b/include/Rect.h
@@ -4,8 +4,5 @@
 
 namespace ccm
 {
-	struct Rect
-	{
-		SDL_Rect rect{};
-	};
+	using Rect = SDL_Rect;
 }

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -13,13 +13,13 @@ namespace ccm
 	Grid::Grid(const Rect& position, int columns, int rows)
 		: m_object(position, Color(128, 128, 128, 255)), m_numColumns(columns), m_numRows(rows)
 	{
-		int tileWidth = m_object.rect.rect.w / columns;
-		int tileHeigh = m_object.rect.rect.h / rows;
+		int tileWidth = m_object.rect.w / columns;
+		int tileHeigh = m_object.rect.h / rows;
 
 		m_tiles.reserve(columns * rows);
 		for (int y = 0; y < m_numRows; ++y)
 			for (int x = 0; x < m_numColumns; ++x)
-				m_tiles.emplace_back(x * tileWidth + 1 + position.rect.x, y * tileHeigh + 1 + position.rect.y, tileWidth - 2, tileHeigh - 2);
+				m_tiles.emplace_back(x * tileWidth + 1 + m_object.rect.x, y * tileHeigh + 1 + m_object.rect.y, tileWidth - 2, tileHeigh - 2);
 	}
 
 	Tile& Grid::getTile(int x, int y)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -23,7 +23,7 @@ namespace ccm
 	void Renderer::draw(const Object& obj)
 	{
 		setRenderColor(obj.color);
-		SDL_RenderFillRect(m_renderer, &obj.rect.rect);
+		SDL_RenderFillRect(m_renderer, &obj.rect);
 	}
 
 	void Renderer::render()
@@ -38,6 +38,6 @@ namespace ccm
 
 	void Renderer::fillRect(const Rect& rect)
 	{
-		SDL_RenderFillRect(m_renderer, &rect.rect);
+		SDL_RenderFillRect(m_renderer, &rect);
 	}
 }


### PR DESCRIPTION
Changed Rect implementation to remvove the repetition of rect. Because we realised that when using ccm::Rect rect, to access the actual data we would need to use rect.rect.x rather than just rect.x