### PR TITLE
Changed TextureGenerator singleton to use ccm::Singelton base class

### DIFF
--- a/include/TextureGenerator.h
+++ b/include/TextureGenerator.h
@@ -2,31 +2,25 @@
 
 #include "SDL.h"
 #include "stb_image.h"
-
+#include "Singleton.h"
 #include <string_view>
 #include <assert.h>
 #include <tuple>
 namespace ccm
 {
 	class Renderer;
-	class TextureGenerator
+	class TextureGenerator : public Singleton<TextureGenerator>
 	{
 	private:
 		struct TextureInfo { SDL_Texture* tex; int width, height, pitch; };
 	public:
-
-		/*
-		* Creates an instantiation of the singleton
-		* @Param renderer: reference to the render to use to generate SDL_Textures
-		*/
-		static void create(Renderer& r);
-
+		TextureGenerator(Renderer&);
 		/*
 		* Generates an SDL texture from a file
 		* @param Texture Source: the image file to be loaded
 		* @return: A pointer to the loaded SDL_texture, the width, height, and pitch of the loaded image
 		*/
-		static TextureInfo loadTextureFromFile(std::string_view textureSource);
+		TextureInfo loadTextureFromFile(std::string_view textureSource);
 	private:
 		inline static Renderer* m_renderer;
 	};

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -4,7 +4,7 @@ namespace ccm
 {
 	Texture::Texture(std::string_view textureSource)
 	{
-		auto[pTex, width, height, pitch] = TextureGenerator::loadTextureFromFile(textureSource);
+		auto[pTex, width, height, pitch] = TextureGenerator::getInstance().loadTextureFromFile(textureSource);
 		m_texture.reset(pTex);
 		m_width = width;
 		m_height = height;
@@ -12,7 +12,7 @@ namespace ccm
 	}
 
 	SDL_Texture& Texture::draw() const
-{
+	{
 		return *m_texture;
 	}
 

--- a/src/TextureGenerator.cpp
+++ b/src/TextureGenerator.cpp
@@ -3,7 +3,7 @@
 
 namespace ccm
 {
-	void TextureGenerator::create(Renderer& r)
+	TextureGenerator::TextureGenerator(Renderer& r)
 	{
 		if (!m_renderer)
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ int SDL_main(int argc, char* argv[])
 #endif
 	ccm::Application app("Game", 1280, 720);
 	ccm::Renderer renderer{ app };
-	ccm::TextureGenerator::create(renderer);
+	ccm::TextureGenerator::initialize(renderer);
 	auto[width, height] = app.getSize();
 	ccm::Texture mario("../../assets/mario.jpg");
 	ccm::Object obj{ ccm::Rect{width / 2, height / 2, 128, 128}, mario };


### PR DESCRIPTION
TextureGenerator is a singleton so now it properly inherits from the ccm::Singelton utility class